### PR TITLE
Compatibility patches

### DIFF
--- a/bin/umake.pl
+++ b/bin/umake.pl
@@ -1545,7 +1545,7 @@ foreach my $chr (@chrs) {
             print MAK "$splitDir/$chrchr/subset.OK:\n";
         }
         print MAK "\tmkdir --p $splitDir/$chrchr\n";
-        my $cmd = "zcat $mvcf | grep -E \\\"\\sPASS\\s|^#\\\" | ".getConf("BGZIP")." -c > $subsetPrefix.PASS.vcf.gz";
+        my $cmd = "zcat $mvcf | grep -E \\\"[[:space:]]PASS[[:space:]]|^#\\\" | ".getConf("BGZIP")." -c > $subsetPrefix.PASS.vcf.gz";
         writeLocalCmd($cmd);
         writeTouch("$splitDir/$chrchr/subset", "$subsetPrefix.PASS.vcf.gz");
 

--- a/scripts/diff_results_umake.sh
+++ b/scripts/diff_results_umake.sh
@@ -178,7 +178,7 @@ done
 
 set +e                          # Do not fail on errors
 for file in $EXPECTED_VCF_GZS; do
-    zdiff -I"^##filedate=.*$" -I"^#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	.*$" $file ${file/$EXPECTED_DIR/$RESULTS_DIR} >> $DIFFRESULTS;
+    zdiff -I"^##filedate=.*$" -I"^#CHROM\sPOS\sID\sREF\sALT\sQUAL\sFILTER\sINFO\sFORMAT\s.*$" $file ${file/$EXPECTED_DIR/$RESULTS_DIR} >> $DIFFRESULTS;
     if [ $? -ne 0 ] ; then
         echo "$file failed. See mismatches in $DIFFRESULTS"
         status=2

--- a/test/umake/expected/umaketest/umake_test.snpcall.Makefile
+++ b/test/umake/expected/umaketest/umake_test.snpcall.Makefile
@@ -11,7 +11,7 @@ split20: $(OUT_DIR)/split/chr20/chr20.filtered.PASS.split.vcflist.OK
 
 $(OUT_DIR)/split/chr20/subset.OK: $(OUT_DIR)/vcfs/chr20/chr20.filtered.vcf.gz.OK
 	mkdir --p $(OUT_DIR)/split/chr20
-	bash -c "set -e -o pipefail; zcat $(OUT_DIR)/vcfs/chr20/chr20.filtered.vcf.gz | grep -E \"\sPASS\s|^#\" | $(GOTCLOUD_ROOT)/bin/bgzip -c > $(OUT_DIR)/split/chr20/chr20.filtered.PASS.vcf.gz"
+	bash -c "set -e -o pipefail; zcat $(OUT_DIR)/vcfs/chr20/chr20.filtered.vcf.gz | grep -E \"[[:space:]]PASS[[:space:]]|^#\" | $(GOTCLOUD_ROOT)/bin/bgzip -c > $(OUT_DIR)/split/chr20/chr20.filtered.PASS.vcf.gz"
 	if [ -e  $(OUT_DIR)/split/chr20/chr20.filtered.PASS.vcf.gz ]; then touch $(OUT_DIR)/split/chr20/subset.OK; else exit 1; fi
 
 $(OUT_DIR)/split/chr20/chr20.filtered.PASS.split.vcflist.OK: $(OUT_DIR)/split/chr20/subset.OK


### PR DESCRIPTION
The snpcall test wasn't passing in our cluster based on CentOS 5 due to some issues with older versions of grep and zdiff. These changes got it working in our environment, and I they should work for newer systems as well (the tests pass on a CentOS 7 system with these changes.)