### PR TITLE
Fix a bug for the SGE batch mode of snpcall.

### DIFF
--- a/scripts/runcluster.pl
+++ b/scripts/runcluster.pl
@@ -352,6 +352,7 @@ sub waitforcommand {
     #   query for the batch system and see if the job is still there
     while (1) {
         foreach (1 .. $opts{waittries}) {
+            sleep($opts{waitinterval});
             if (-r "$shell.err") {
                 unlink("$shell.err");
                 if ($opts{verbose}) { print "Found $shell.err\n"; }
@@ -363,7 +364,6 @@ sub waitforcommand {
                 return 0;
             }
             if ($opts{verbose}) { print "Wait $_\n"; }
-            sleep($opts{waitinterval});
         }
         if ($opts{verbose}) { print "Trying query: $querycmd\n"; }
         my $qout = "/tmp/$$.queryoutput";


### PR DESCRIPTION
When useing the sge mode of gotcloud on a cluster, runcluster.pl will periodically check
the status of steps through the existience of .ok and .err files. On top of this, it will
periodically check the status of a step by searching the output of `qstat` for the jobid.
Occaisionally, a step will finish after a check for .ok and .err files is made, but before
a check for qstat is made. GotCloud will throw an error.

This patch moves the pause between checking for .err/.ok files and checking the queue such
that .ok/.err files are checked immediately before the queue is checked.

This has been tested only on one instance: snpcall was failing for a random subset of regions
before the patch was applied. After patching, snpcall was rerun, and the errors did not
appear again.